### PR TITLE
add setup.cfg to allow easy rpm building

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_rpm]
+release = 1%{?dist}


### PR DESCRIPTION
Adding a setup.cfg so we can build RPMs without having to commit to installing fpm