### PR TITLE
Cleanup of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,36 @@
 # Author: gdestuynder@mozilla.com
 
 import os
+import subprocess
 from setuptools import setup
+
+VERSION = '1.0.11'
+
+
+def git_version():
+    """ Return the git revision as a string """
+    def _minimal_ext_cmd(cmd):
+        # construct minimal environment
+        env = {}
+        for envvar in ['SYSTEMROOT', 'PATH']:
+            val = os.environ.get(envvar)
+            if val is not None:
+                env[envvar] = val
+        # LANGUAGE is used on win32
+        env['LANGUAGE'] = 'C'
+        env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
+        out = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                               env=env).communicate()[0]
+        return out
+
+    try:
+        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
+        git_revision = out.strip().decode('ascii')
+    except OSError:
+        git_revision = u"Unknown"
+
+    return git_revision
 
 
 def read(fname):
@@ -15,10 +44,11 @@ def read(fname):
 setup(
     name="mozdef_client",
     py_modules=['mozdef_client'],
-    version="1.0.11",
+    version=VERSION,
     author="Guillaume Destuynder",
     author_email="gdestuynder@mozilla.com",
-    description=("A client library to send messages/events using MozDef"),
+    description=('A client library to send messages/events using MozDef\n' +
+                 'This package is built upon commit '+git_version()),
     license="MPL",
     keywords="mozdef client library",
     url="https://github.com/mozilla/mozdef_client",

--- a/setup.py
+++ b/setup.py
@@ -6,27 +6,28 @@
 # Author: gdestuynder@mozilla.com
 
 import os
-from setuptools import setup, find_packages
+from setuptools import setup
+
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
-    name = "mozdef_client",
-        py_modules = ['mozdef_client'],
-        version = "1.0.11",
-        author = "Guillaume Destuynder",
-        author_email = "gdestuynder@mozilla.com",
-        description = ("A client library to send messages/events using MozDef"),
-        license = "MPL",
-        keywords = "mozdef client library",
-        url = "https://github.com/gdestuynder/mozdef_client",
-        long_description = read('README.rst'),
-        install_requires = ['requests_futures', 'pytz', 'boto3'],
-        classifiers = [
-            "Development Status :: 5 - Production/Stable",
-            "Topic :: System :: Logging",
-            "Topic :: Software Development :: Libraries :: Python Modules",
-            "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-        ],
+    name="mozdef_client",
+    py_modules=['mozdef_client'],
+    version="1.0.11",
+    author="Guillaume Destuynder",
+    author_email="gdestuynder@mozilla.com",
+    description=("A client library to send messages/events using MozDef"),
+    license="MPL",
+    keywords="mozdef client library",
+    url="https://github.com/mozilla/mozdef_client",
+    long_description=read('README.rst'),
+    install_requires=['requests_futures', 'pytz', 'boto3'],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Topic :: System :: Logging",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    ],
 )


### PR DESCRIPTION
* Fixes the URL (was pointed off at kang's repo)
* makes setup.py pep8 cleaner
* postpends the git hash to the package description, for exact package versioning (we're 14 commits past 1.0.11 at this point, and this becomes a nightmare to track in RPM-land).