### PR TITLE
Close requests sessions when the message object is deleted

### DIFF
--- a/mozdef_client/message.py
+++ b/mozdef_client/message.py
@@ -56,6 +56,12 @@ class MozDefMessage(object):
         self._verify_certificate = False
         self._verify_path = None
 
+    def __del__(self):
+        '''
+            Close out any Sessions we started.
+        '''
+        self._httpsession.close()
+
     def validate(self):
         return True
 


### PR DESCRIPTION
This is mostly so that we don't rely on Requests to clean up.  Some tests which use this module can get a warning about leaked connections.