### PR TITLE
Remove jmespath from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 boto3==1.12.39
 botocore==1.15.39
 futures==3.1.1
-jmespath==0.9.5
 pytz==2019.3
 requests==2.23.0
 requests-futures==1.0.0


### PR DESCRIPTION
jmespath is helpful for paginating results from boto, but it's not implemented in mozdef_client.

Having it listed as a requirement produces a knock-on issue for setuptools' entry_points, which looks for requirements and needs them to be installed.  So jmespath needs to be either added to setup.py, or removed completely, and removing makes more sense.