### PR TITLE
Modernize changes to RPM building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ install: clean ## install the package to the active Python's site-packages
 	python setup.py install
 
 rpm:
-	fpm -s python -t rpm -d pytz -d python-requests-futures --replaces python-mozdef ./setup.py
+	fpm -s python -t rpm -d pytz -d python-requests-futures --provides python-mozdef-client --rpm-dist "$$(rpmbuild -E '%{?dist}' | sed -e 's#^\.##')" ./setup.py
 
 deb:
 	fpm -s python -t deb ./setup.py


### PR DESCRIPTION
Removes the --replaces python-mozdef, which, while true, is ancient and unnecessary anymore.
Adds --provides python-mozdef-client, which is important for RPM/pip packaging, as _ is technically incorrect.
Adds --rpm-dist to let us indicate .el7 and .el8 package types in the name as we build.